### PR TITLE
Session and SessionManager names shortened

### DIFF
--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/HttpConnection.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/HttpConnection.java
@@ -20,12 +20,8 @@ public class HttpConnection extends Connection {
   private HttpClient client;
   private String authString;
   private static final String API_URL_BASE = "https://server2.tygron.com:3022/api/";
-  private static final String API_SLOTS = "slots/";
-  private static final String API_TOKEN_SUFFIX = "&token=";
   private static final String API_JSON_SUFFIX = "?f=JSON";
-  
-  // API_URL_BASE + API_SLOTS + session.getId() + "/" + "lists/actionmenus/" + API_JSON_SUFFIX + API_TOKEN_SUFFIX + session.getServerToken();
-  
+
   /**
    * Creates a Tygron connection using some settings. 
    * @param tygronSettings the settings that should be used.

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/HttpConnection.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/HttpConnection.java
@@ -20,8 +20,12 @@ public class HttpConnection extends Connection {
   private HttpClient client;
   private String authString;
   private static final String API_URL_BASE = "https://server2.tygron.com:3022/api/";
+  private static final String API_SLOTS = "slots/";
+  private static final String API_TOKEN_SUFFIX = "&token=";
   private static final String API_JSON_SUFFIX = "?f=JSON";
-
+  
+  // API_URL_BASE + API_SLOTS + session.getId() + "/" + "lists/actionmenus/" + API_JSON_SUFFIX + API_TOKEN_SUFFIX + session.getServerToken();
+  
   /**
    * Creates a Tygron connection using some settings. 
    * @param tygronSettings the settings that should be used.

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/Session.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/Session.java
@@ -15,12 +15,12 @@ import org.json.JSONObject;
 public class Session {
 
   private static Connection apiConnection;
-  private String sessionName;
-  private String sessionType;
-  private String sessionLanguage;
-  private String sessionClientToken;
-  private String sessionServerToken;
-  private int sessionId;
+  private String name;
+  private String type;
+  private String language;
+  private String clientToken;
+  private String serverToken;
+  private int id;
 
   /**
    * Tygron Session Object.
@@ -28,8 +28,8 @@ public class Session {
   public Session(Connection localApiConnection) {
     apiConnection = localApiConnection;
     setName(""); 
-    sessionClientToken = "";
-    sessionServerToken = "";
+    clientToken = "";
+    serverToken = "";
   }
 
   /**
@@ -39,16 +39,16 @@ public class Session {
    *          The new session name.
    */
   public void setName(String newName) {
-    this.sessionName = newName;
+    this.name = newName;
   }
   
   /**
    * Get the session name.
    * 
-   * @return The new session name.
+   * @return The session name.
    */
   public String getName() {
-    return this.sessionName;
+    return this.name;
   }
 
   /**
@@ -58,7 +58,7 @@ public class Session {
    *          The new session type.
    */
   public void setType(String newType) {
-    this.sessionType = newType;
+    this.type = newType;
   }
 
   /**
@@ -68,7 +68,7 @@ public class Session {
    *          The new session language.
    */
   public void setLanguage(String newLanguage) {
-    this.sessionLanguage = newLanguage;
+    this.language = newLanguage;
   }
 
   /**
@@ -77,34 +77,46 @@ public class Session {
    * @param session id
    *          The new session id.
    */
-  public void setSessionId(int newId) {
-    this.sessionId = newId;
+  public void setId(int newId) {
+    this.id = newId;
   }
   
   /**
    * Get the session id.
    * 
-   * @param session id
-   *          Get session id.
+   * @return The session id.
    */
-  public int getSessionId() {
-    return this.sessionId;
+  public int getId() {
+    return this.id;
   }  
   
   /**
    * Set a new server token.
-   * @param serverToken The server token.
+   * 
+   * @param serverToken
+   * 		The server token.
    */
   public void setServerToken(String serverToken){
-    this.sessionServerToken = serverToken;
+    this.serverToken = serverToken;
+  }
+  
+  /**
+   * Get the server token.
+   *
+   * @return The server token.
+   */
+  public String getServerToken(){
+    return this.serverToken;
   }
   
   /**
    * Set a client token.
-   * @param clientToken The client token.
+   * 
+   * @param clientToken
+   * 		The client token.
    */
   public void setClientToken(String clientToken){
-    this.sessionClientToken = clientToken;
+    this.clientToken = clientToken;
   }
 
   /**
@@ -112,10 +124,10 @@ public class Session {
    */
   public String toString() {
     JSONObject str = new JSONObject();
-    str.put("name", this.sessionName);
-    str.put("sessionType", this.sessionType);
-    str.put("language", this.sessionLanguage);
-    str.put("id", this.sessionId);
+    str.put("name", this.name);
+    str.put("sessionType", this.type);
+    str.put("language", this.language);
+    str.put("id", this.id);
     return str.toString();
   }
 }

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
@@ -51,7 +51,7 @@ public class SessionManager {
    */
   public boolean joinSession(Session session, int slotId) {
 
-    JSONArray dataArray = new JSONArray();
+	JSONArray dataArray = new JSONArray();
     dataArray.put(slotId);      // Server slot ID
     dataArray.put("VIEWER");    // My application type: EDITOR, VIEWER, ADMIN, BEAM 
     dataArray.put("");          // My client address (optional)
@@ -61,6 +61,7 @@ public class SessionManager {
     JSONObject data = apiConnection.callPostEventObject(
         "services/event/IOServicesEventType/JOIN_SESSION/", dataArray);
     
+    session.setId(slotId);
     session.setClientToken(data.getJSONObject("client").getString("clientToken"));
     session.setServerToken(data.getString("serverToken"));
     

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
@@ -51,7 +51,7 @@ public class SessionManager {
    */
   public boolean joinSession(Session session, int slotId) {
 
-	JSONArray dataArray = new JSONArray();
+    JSONArray dataArray = new JSONArray();
     dataArray.put(slotId);      // Server slot ID
     dataArray.put("VIEWER");    // My application type: EDITOR, VIEWER, ADMIN, BEAM 
     dataArray.put("");          // My client address (optional)

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
@@ -50,8 +50,8 @@ public class SessionManager {
    * @return whether the join was successful or not.
    */
   public boolean joinSession(Session session, int slotId) {
-	
-    JSONArray dataArray = new JSONArray();
+
+	JSONArray dataArray = new JSONArray();
     dataArray.put(slotId);      // Server slot ID
     dataArray.put("VIEWER");    // My application type: EDITOR, VIEWER, ADMIN, BEAM 
     dataArray.put("");          // My client address (optional)

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
@@ -35,7 +35,7 @@ public class SessionManager {
       localSession.setName(row.getString("name"));
       localSession.setType(row.getString("sessionType"));
       localSession.setLanguage(row.getString("sessionType"));
-      localSession.setSessionId(row.getInt("id"));
+      localSession.setId(row.getInt("id"));
 
       // Add to datalist
       returnList.add(localSession);
@@ -82,7 +82,7 @@ public class SessionManager {
     List<Session> availableList = getJoinableSessions();
     for (int i = 0;i < availableList.size();i++) {
       if (mapName.equals(availableList.get(i).getName())) {
-        slot = availableList.get(i).getSessionId();
+        slot = availableList.get(i).getId();
       }
     }
     

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
@@ -50,8 +50,8 @@ public class SessionManager {
    * @return whether the join was successful or not.
    */
   public boolean joinSession(Session session, int slotId) {
-
-	JSONArray dataArray = new JSONArray();
+	
+    JSONArray dataArray = new JSONArray();
     dataArray.put(slotId);      // Server slot ID
     dataArray.put("VIEWER");    // My application type: EDITOR, VIEWER, ADMIN, BEAM 
     dataArray.put("");          // My client address (optional)


### PR DESCRIPTION
Many fields in Session had a prefix of "session", like sessionId.
The fields are properties of a Session, there's no need to prefix them with "session".
