### PR TITLE
Sessionfix

### DIFF
--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/HttpConnection.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/HttpConnection.java
@@ -74,9 +74,6 @@ public class HttpConnection {
         + API_JSON_SUFFIX;
   }
 
-  public int getSessionId() {
-    return sessionId;
-  }
   /**
    * Calls a get event without a session.
    * @param eventName the event as described in the API

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/HttpConnection.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/HttpConnection.java
@@ -74,6 +74,9 @@ public class HttpConnection {
         + API_JSON_SUFFIX;
   }
 
+  public int getSessionId() {
+    return sessionId;
+  }
   /**
    * Calls a get event without a session.
    * @param eventName the event as described in the API

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/Session.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/Session.java
@@ -85,7 +85,8 @@ public class Session {
    */
   public boolean closeSession(boolean keepAlive) {
 
-    logger.info("Closing session #" + this.id + " with clientToken " + this.clientToken + " (keepalive: " + keepAlive + ")");
+    logger.info("Closing session #" + this.id + " with clientToken " + this.clientToken
+        + " (keepalive: " + keepAlive + ")");
     
     JSONArray dataArray = new JSONArray();
     dataArray.put(this.id); // Server slot ID
@@ -147,7 +148,6 @@ public class Session {
    */
   public void setId(int newId) {
     this.id = newId;
-    apiConnection.setSessionId(newId);
   }
 
   /**
@@ -168,7 +168,6 @@ public class Session {
   public void setServerToken(String serverToken) {
     logger.debug("Session serverToken=" + serverToken);
     this.serverToken = serverToken;
-    apiConnection.setServerToken(serverToken);
   }
 
   /**

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
@@ -95,6 +95,7 @@ public class SessionManager {
     
     // Try to find a session with the name if it already exists
     List<Session> availableList = getJoinableSessions();
+    System.out.println(availableList);
     for (int i = 0;i < availableList.size();i++) {
       if (mapName.equals(availableList.get(i).getName())) {
         slot = availableList.get(i).getId();
@@ -112,6 +113,10 @@ public class SessionManager {
     
     // Join / startup the session
     joinSession(sess);
+    
+    // Set server token and session id in connection
+    apiConnection.setServerToken(sess.getServerToken());
+    apiConnection.setSessionId(slot);
     
     return sess;
   }

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
@@ -76,6 +76,10 @@ public class SessionManager {
     
     session.start();
     
+    // Set server token and session id in connection
+    apiConnection.setServerToken(session.getServerToken());
+    apiConnection.setSessionId(session.getId());
+    
     return true;
   }
   
@@ -112,10 +116,6 @@ public class SessionManager {
     
     // Join / startup the session
     joinSession(sess);
-    
-    // Set server token and session id in connection
-    apiConnection.setServerToken(sess.getServerToken());
-    apiConnection.setSessionId(slot);
     
     return sess;
   }

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
@@ -95,6 +95,7 @@ public class SessionManager {
     
     // Try to find a session with the name if it already exists
     List<Session> availableList = getJoinableSessions();
+    System.out.println(availableList);
     for (int i = 0;i < availableList.size();i++) {
       if (mapName.equals(availableList.get(i).getName())) {
         slot = availableList.get(i).getId();

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/SessionManager.java
@@ -95,7 +95,6 @@ public class SessionManager {
     
     // Try to find a session with the name if it already exists
     List<Session> availableList = getJoinableSessions();
-    System.out.println(availableList);
     for (int i = 0;i < availableList.size();i++) {
       if (mapName.equals(availableList.get(i).getName())) {
         slot = availableList.get(i).getId();


### PR DESCRIPTION
There were inconsistencies when trying to join a session if multiple sessions are available. The httpconnection was assigned the sessionid and servertoken of the last session in the joinablesessions list. This is now fixed so only the selected session's id and servertoken are assigned to connection
