### PR TITLE
Fixed Serializable sonarqube warnings

### DIFF
--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/api/Connector.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/api/Connector.java
@@ -8,17 +8,10 @@ import nl.tudelft.contextproject.tygron.Settings;
 import nl.tudelft.contextproject.tygron.handlers.JsonObjectResultHandler;
 import nl.tudelft.contextproject.tygron.objects.User;
 
-import java.io.Serializable;
-
 /**
  * The TygronConnector is the bridge between the Tygron API and JAVA.
  */
-public class Connector implements Serializable {
-
-  /**
-   * Seial version ID.
-   */
-  private static final long serialVersionUID = 1L;
+public class Connector {
 
   private static final Logger logger = LoggerFactory.getLogger(Connector.class);
 

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/api/Session.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/api/Session.java
@@ -7,7 +7,6 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,12 +17,7 @@ import java.util.List;
  * a session with JOIN_SESSION. You can either close your own session with
  * CLOSE_SESSION or kill the session with KILL_SESSION.
  */
-public class Session implements Serializable {
-  /**
-   * Serial version ID.
-   */
-  private static final long serialVersionUID = 1L;
-
+public class Session {
   private static final Logger logger = LoggerFactory.getLogger(Session.class);
 
   // Session oriented

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/eis/Configuration.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/eis/Configuration.java
@@ -1,14 +1,6 @@
 package nl.tudelft.contextproject.tygron.eis;
 
-import java.io.Serializable;
-
-public class Configuration implements Serializable {
-
-  /**
-   * Serial version ID.
-   */
-  private static final long serialVersionUID = 1L;
-  
+public class Configuration {
   private int stakeholders;
   private String map;
   private int slot;

--- a/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/eis/TygronInterfaceImpl.java
+++ b/tygron-environment/src/main/java/nl/tudelft/contextproject/tygron/eis/TygronInterfaceImpl.java
@@ -27,12 +27,11 @@ public class TygronInterfaceImpl extends AbstractEnvironment {
    * Serial version.
    */
   private static final long serialVersionUID = 1L;
-  
-  
-  protected Connector connector;
-  protected Session controller;
-  protected Configuration configuration;
-  protected Environment environment;
+
+  protected transient Connector connector;
+  protected transient Session controller;
+  protected transient Configuration configuration;
+  protected transient Environment environment;
   
   /**
    * Constructs the EIS.


### PR DESCRIPTION
Made the fields in EnvironmentImpl `transient` instead of `Serializable`. They shouldn't be serialized.
