### PR TITLE
Money transfer between stakeholders

### DIFF
--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/Environment.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/Environment.java
@@ -14,6 +14,8 @@ import nl.tudelft.contextproject.tygron.objects.PopUpHandler;
 import nl.tudelft.contextproject.tygron.objects.Stakeholder;
 import nl.tudelft.contextproject.tygron.objects.StakeholderList;
 import nl.tudelft.contextproject.tygron.objects.ZoneList;
+import nl.tudelft.contextproject.tygron.objects.indicators.Indicator;
+import nl.tudelft.contextproject.tygron.objects.indicators.IndicatorFinance;
 import nl.tudelft.contextproject.tygron.objects.indicators.IndicatorList;
 import nl.tudelft.contextproject.util.PolygonUtil;
 
@@ -424,6 +426,23 @@ public class Environment implements Runnable {
   public boolean withinMargin(Polygon selectedLand, double surface) {
     return selectedLand.calculateArea2D() < surface * (1 + errorMargin) 
         && selectedLand.calculateArea2D() > surface * (1 - errorMargin);
+  }
+  
+  /**
+   * Gets the current budget of the given stakeholder.
+   * @param stakeholderId The stakeholder's id.
+   * @return The current budget.
+   */
+  public double getBudget(int stakeholderId) {
+    for (Indicator indicator : indicatorList) {
+      if (indicator.getType().equals("FINANCE")) {
+        IndicatorFinance indicatorFinance = (IndicatorFinance) indicator;
+        if (indicatorFinance.getActorId() == stakeholderId) {
+          return indicatorFinance.getCurrent();
+        }
+      }
+    }
+    return -1;
   }
 }
 

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/actions/AskMoneyAction.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/actions/AskMoneyAction.java
@@ -1,0 +1,51 @@
+package nl.tudelft.contextproject.tygron.api.actions;
+
+import nl.tudelft.contextproject.tygron.api.CallType;
+import nl.tudelft.contextproject.tygron.api.Environment;
+import nl.tudelft.contextproject.tygron.api.HttpConnection;
+import nl.tudelft.contextproject.tygron.api.Session;
+import nl.tudelft.contextproject.tygron.handlers.StringResultHandler;
+
+import org.json.JSONArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AskMoneyAction {
+  
+  private static final Logger logger = LoggerFactory.getLogger(AskMoneyAction.class);
+  
+  private Session session;
+  private Environment environment;
+  
+  public AskMoneyAction(Session session) {
+    this.session = session;
+    this.environment = session.getEnvironment();
+  }
+  
+  /**
+   * Ask money from the given stakeholder.
+   * @param giverId The id of the stakeholder to ask money from.
+   * @param amount The amount of money to ask for.
+   */
+  public void askMoney(int giverId, double amount) {
+    logger.debug("Asking money from stakeholder #" + giverId);
+    if (environment.getBudget(giverId) >= amount) {
+      AskMoneyRequest askMoneyRequest = new AskMoneyRequest(environment.getStakeholderId(), giverId, amount);
+      HttpConnection.getInstance().execute("event/PlayerEventType/MONEY_TRANSFER_ASK/",
+          CallType.POST, new StringResultHandler(), session, askMoneyRequest);
+    } else {
+      logger.debug("Stakeholder #" + giverId + " has less money than asked");
+    }
+  }
+  
+  class AskMoneyRequest extends JSONArray {
+    public AskMoneyRequest(int askerId, int giverId, double amount) {
+      this.put(askerId);
+      this.put("SUBSIDY");
+      this.put(giverId);
+      this.put(askerId);
+      this.put("");
+      this.put(amount);
+    }
+  }
+}

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/actions/GiveMoneyAction.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/actions/GiveMoneyAction.java
@@ -1,0 +1,52 @@
+package nl.tudelft.contextproject.tygron.api.actions;
+
+import nl.tudelft.contextproject.tygron.api.CallType;
+import nl.tudelft.contextproject.tygron.api.Environment;
+import nl.tudelft.contextproject.tygron.api.HttpConnection;
+import nl.tudelft.contextproject.tygron.api.Session;
+import nl.tudelft.contextproject.tygron.handlers.StringResultHandler;
+
+import org.json.JSONArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class GiveMoneyAction {
+  
+  private static final Logger logger = LoggerFactory.getLogger(GiveMoneyAction.class);
+  
+  private Session session;
+  private Environment environment;
+  
+  public GiveMoneyAction(Session session) {
+    this.session = session;
+    this.environment = session.getEnvironment();
+  }
+  
+  /**
+   * Give money to the given stakeholder.
+   * @param receiverId The id of the stakeholder to give money to.
+   * @param amount The amount of money to ask for.
+   */
+  public void giveMoney(int receiverId, double amount) {
+    logger.debug("Giving money to stakeholder #" + receiverId);
+    if (environment.getBudget(environment.getStakeholderId()) >= amount) {
+      GiveMoneyRequest giveMoneyRequest = new GiveMoneyRequest(environment.getStakeholderId(), receiverId, amount);
+      HttpConnection.getInstance().execute("event/PlayerEventType/MONEY_TRANSFER_GIVE/",
+          CallType.POST, new StringResultHandler(), session, giveMoneyRequest);
+    } else {
+      logger.debug("Selected stakeholder has less money than given");
+    }
+  }
+  
+  class GiveMoneyRequest extends JSONArray {
+    public GiveMoneyRequest(int giverId, int receiverId, double amount) {
+      this.put(giverId);
+      this.put("TRANSFER");
+      this.put(giverId);
+      this.put(receiverId);
+      this.put("");
+      this.put(amount);
+    }
+  }
+}

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/objects/indicators/IndicatorFinance.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/objects/indicators/IndicatorFinance.java
@@ -9,6 +9,7 @@ import org.json.JSONObject;
 public class IndicatorFinance extends Indicator {
   private double target;
   private double currentBudget;
+  private int actorId;
   
   /**
    * Constructs a TygronIndicatorFinance from a JSONObject.
@@ -18,6 +19,7 @@ public class IndicatorFinance extends Indicator {
     super(input);
     target = input.getJSONObject("targets").getJSONArray("0").getDouble(0);
     currentBudget = input.getJSONObject("exactActorValues").getDouble("CURRENT");
+    actorId = input.getInt("actorID");
   }
 
   @Override
@@ -33,5 +35,9 @@ public class IndicatorFinance extends Indicator {
   @Override
   public double getCurrent() {
     return currentBudget;
+  }
+  
+  public int getActorId() {
+    return actorId;
   }
 }


### PR DESCRIPTION
Stakeholder can give or ask money to and from a given stakeholder.

Note: Not all stakeholders have the option to transfer money in-game. This is not a problem now, because any and every action is allowed to every stakeholder through the API, without errors. But once an agent is deployed in an actual game, it would be strange for it to transfer money when it doesn't even have this option in its action menu.
