### PR TITLE
Dependency cleanup

### DIFF
--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/Environment.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/Environment.java
@@ -30,7 +30,6 @@ public class Environment implements Runnable {
   private final double errorMargin = 0.10;
 
   // Environment oriented
-  private Session session;
   private PopUpHandler popUpHandler;
 
   // Session data oriented
@@ -46,8 +45,7 @@ public class Environment implements Runnable {
    * Creates an environment that communicates with the session API.
    * @param session The session.
    */
-  public Environment(Session session) {
-    this.session = session;
+  public Environment() {
     stakeholderId = -1;
     environmentThread = new Thread(this);
 
@@ -103,7 +101,7 @@ public class Environment implements Runnable {
     JSONArray param = new JSONArray();
     param.put(set);
     HttpConnection.getInstance().execute(allowInteraction, CallType.POST,
-            new JsonObjectResultHandler(), session, param);
+            new JsonObjectResultHandler(), true, param);
   }
   
   /**
@@ -136,14 +134,14 @@ public class Environment implements Runnable {
   public void setStakeholder(int stakeholderId) {
     this.stakeholderId = stakeholderId;
     boolean retValue = HttpConnection.getInstance().execute("event/PlayerEventType/STAKEHOLDER_SELECT",
-            CallType.POST, new BooleanResultHandler(), session,
-            new StakeholderSelectRequest(stakeholderId, session.getClientToken()));
+            CallType.POST, new BooleanResultHandler(), true,
+            new StakeholderSelectRequest(stakeholderId, HttpConnection.getInstance().getData().getClientToken()));
     logger.info("Setting stakeholder to #" + stakeholderId + ". Operation " 
         + ((retValue) ? "success!" : "failed!" ));
     if (!retValue) {
       throw new RuntimeException("Stakeholder could not be selected!");
     } else {
-      popUpHandler = new PopUpHandler(session, stakeholderId);
+      popUpHandler = new PopUpHandler(this, stakeholderId);
     }
   }
   
@@ -164,7 +162,7 @@ public class Environment implements Runnable {
   public void releaseStakeholder() {
     logger.info("Releasing stakeholder #" + stakeholderId);
     HttpConnection.getInstance().execute("event/LogicEventType/STAKEHOLDER_RELEASE/",
-            CallType.POST, new BooleanResultHandler(), session,
+            CallType.POST, new BooleanResultHandler(), true,
             new StakeholderReleaseRequest(stakeholderId));
     stakeholderId = -1;
     popUpHandler = null;
@@ -270,7 +268,7 @@ public class Environment implements Runnable {
   private void getMapWidth() {
     if (mapWidth == 0) {
       mapWidth = HttpConnection.getInstance().execute("lists/settings/31/",
-              CallType.GET, new JsonObjectResultHandler(), session).getInt("value");
+              CallType.GET, new JsonObjectResultHandler(), true).getInt("value");
     }
   }
   

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/Environment.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/Environment.java
@@ -52,14 +52,14 @@ public class Environment implements Runnable {
     environmentThread = new Thread(this);
 
     loaderMap = new HashMap<>();
-    putLoader(new BuildingListLoader(session));
-    putLoader(new EconomyListLoader(session));
-    putLoader(new FunctionMapLoader(session));
-    putLoader(new IndicatorListLoader(session));
-    putLoader(new LandMapLoader(session));
-    putLoader(new StakeholderListLoader(session));
-    putLoader(new ZoneListLoader(session));
-    putLoader(new ServerWordsLoader(session));
+    putLoader(new BuildingListLoader());
+    putLoader(new EconomyListLoader());
+    putLoader(new FunctionMapLoader());
+    putLoader(new IndicatorListLoader());
+    putLoader(new LandMapLoader());
+    putLoader(new StakeholderListLoader());
+    putLoader(new ZoneListLoader());
+    putLoader(new ServerWordsLoader());
   }
 
   public void putLoader(Loader<?> loader) {

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/HttpConnection.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/HttpConnection.java
@@ -50,6 +50,10 @@ public class HttpConnection {
     this.data = data;
   }  
 
+  public HttpConnectionData getData() {
+    return this.data;
+  }  
+  
   /**
    * Return the HttpConnection instance.
    * @return the http connection instance
@@ -76,33 +80,16 @@ public class HttpConnection {
     return execute(eventName, type, resultHandler, isSession, null);
   }
   
-  public <T> T execute(String eventName, CallType type, ResultHandler<T> resultHandler, Session session) {
-    return execute(eventName, type, resultHandler, session, null);
-  }
-  
   /**
    * Calls a method on Tygron's servers.
    * @param <T> A type
    * @param eventName The event name, a part of the URL
    * @param type GET or POST event
    * @param resultHandler The handler used to parse Tygron's result.
-   * @param session The session this call should use, can be null
+   * @param isSession If this is a call to the session or regular API.
    * @param parameters The parameters this request should use, can be null
    * @return a result handled by this request
    */
-  public <T> T execute(String eventName, CallType type, 
-      ResultHandler<T> resultHandler, Session session, JSONArray parameters) {
-    try {
-      HttpRequestBase requester = type.asRequest(parameters);
-      String url = getApiUrl(eventName, session);
-      requester.setURI(new URI(url));
-      String resultString = execute(requester);
-      return resultHandler.handleResult(resultString);
-    } catch (URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
-  }
-  
   public <T> T execute(String eventName, CallType type, ResultHandler<T> resultHandler, boolean isSession, JSONArray parameters) {
     try {
       HttpRequestBase requester = type.asRequest(parameters);
@@ -131,33 +118,19 @@ public class HttpConnection {
   /**
    * Calls the update method on Tygron's servers.
    * @param resultHandler The handler used to parse Tygron's result.
-   * @param session The session this call should use
+   * @param isSession If this is a call to the session or regular API.
    * @param parameters The parameters this request should use
    * @return new updates of the data types requested
    */
-  public JSONObject getUpdate(ResultHandler<JSONObject> resultHandler, Session session, JSONObject parameters) {
+  public JSONObject getUpdate(ResultHandler<JSONObject> resultHandler, boolean isSession, JSONObject parameters) {
     try {
       HttpRequestBase requester = CallType.POST.asRequest(parameters);
-      String url = getApiUrl("update/", session);
+      String url = getApiUrl("update/", isSession);
       requester.setURI(new URI(url));
       String resultString = execute(requester);
       return resultHandler.handleResult(resultString);
     } catch (URISyntaxException e) {
       throw new RuntimeException(e);
-    }
-  }
-
-  /**
-   * Returns Tygron's API url endpoint for a given event name and session.
-   * @param eventName the event that should be called
-   * @param session a session, may be null
-   * @return Tygron's response
-   */
-  protected String getApiUrl(String eventName, Session session) {
-    if (session == null) {
-      return API_URL_BASE + eventName + API_JSON_SUFFIX;
-    } else {
-      return API_URL_BASE + API_SLOTS + session.getId() + API_DELIMITER + eventName + API_JSON_SUFFIX;
     }
   }
 

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/HttpConnection.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/HttpConnection.java
@@ -23,7 +23,7 @@ public class HttpConnection {
   protected HttpClient client;
   protected BasicResponseHandler handler;
 
-  private HttpConnectionData data;
+ 
 
   private static final String API_URL_BASE = "https://server2.tygron.com:3022/api/";
   private static final String API_JSON_SUFFIX = "?f=JSON";
@@ -41,17 +41,18 @@ public class HttpConnection {
 
   private static HttpConnection instance;
   private static Settings settings;
-
+  private static HttpConnectionData data;
+  
   public static void setSettings(Settings settings) {
     HttpConnection.settings = settings;
   }
   
-  public void setData(HttpConnectionData data) {
-    this.data = data;
+  public static void setData(HttpConnectionData newData) {
+    data = newData;
   }  
 
-  public HttpConnectionData getData() {
-    return this.data;
+  public static HttpConnectionData getData() {
+    return data;
   }  
   
   /**

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/JoinableSession.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/JoinableSession.java
@@ -10,7 +10,6 @@ public class JoinableSession {
   private static final Logger logger = LoggerFactory.getLogger(JoinableSession.class);
 
   private String name;
-  private String type;
   private int id;
 
   public JoinableSession() {
@@ -23,7 +22,6 @@ public class JoinableSession {
    */
   public JoinableSession(JSONObject data) {
     name = data.getString("name");
-    type = data.getString("sessionType");
     id = data.getInt("id");
   }
 
@@ -37,14 +35,14 @@ public class JoinableSession {
 
     JSONObject data = HttpConnection.getInstance().execute("services/event/IOServicesEventType/JOIN_SESSION/",
             CallType.POST, new JsonObjectResultHandler(), joinSessionRequest);
-    Session session = new Session(this, data);
+    Session session = new Session(this.id, data);
 
     // Set server token and session id in connection
     HttpConnectionData httpdata = new HttpConnectionData();
     httpdata.setServerToken(session.getServerToken());
     httpdata.setClientToken(session.getClientToken());
     httpdata.setSessionId(session.getId());
-    HttpConnection.getInstance().setData(httpdata);
+    HttpConnection.setData(httpdata);
     
     session.getEnvironment().start();
     return session;
@@ -80,19 +78,6 @@ public class JoinableSession {
    */
   public String getName() {
     return this.name;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  /**
-   * Set a new session type.
-   *
-   * @param newType The new session type.
-   */
-  public void setType(String newType) {
-    this.type = newType;
   }
 
   /**

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/Session.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/Session.java
@@ -25,7 +25,6 @@ public class Session {
   private String name;
   private String platform;
   private String state;
-  private String type;
   private String clientToken;
   private String serverToken;
   private List<String> compatibleOperations;
@@ -47,9 +46,8 @@ public class Session {
    * @param session The session to copy.
    * @param data The json data.
    */
-  public Session(JoinableSession session, JSONObject data) {
-    id = session.getId();
-    type = session.getType();
+  public Session(int sessionId, JSONObject data) {
+    id = sessionId;
 
     clientToken = data.getJSONObject("client").getString("clientToken");
     serverToken = data.getString("serverToken");
@@ -124,19 +122,6 @@ public class Session {
    */
   public String getName() {
     return this.name;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  /**
-   * Set a new session type.
-   *
-   * @param newType The new session type.
-   */
-  public void setType(String newType) {
-    this.type = newType;
   }
 
   /**

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/Session.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/Session.java
@@ -39,7 +39,7 @@ public class Session {
     clientToken = "";
     serverToken = "";
 
-    environment = new Environment(this);
+    environment = new Environment();
   }
 
   /**
@@ -64,7 +64,7 @@ public class Session {
       compatibleOperations.add(jsonArray.get(i).toString());
     }
 
-    environment = new Environment(this);
+    environment = new Environment();
   }
 
   /**

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/ActionListLoader.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/ActionListLoader.java
@@ -11,15 +11,11 @@ import org.slf4j.LoggerFactory;
 public class ActionListLoader extends Loader<ActionList> {
   private static final Logger logger = LoggerFactory.getLogger(BuildingListLoader.class);
 
-  public ActionListLoader(Session session) {
-    super(session);
-  }
-
   @Override
   protected ActionList load() {
     logger.debug("Loading buildings");
     return HttpConnection.getInstance().execute("lists/actionmenus",
-            CallType.GET, new ActionListResultHandler(), session);
+            CallType.GET, new ActionListResultHandler(), true);
   }
 
   @Override

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/BuildingListLoader.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/BuildingListLoader.java
@@ -11,15 +11,11 @@ import org.slf4j.LoggerFactory;
 public class BuildingListLoader extends Loader<BuildingList> {
   private static final Logger logger = LoggerFactory.getLogger(BuildingListLoader.class);
 
-  public BuildingListLoader(Session session) {
-    super(session);
-  }
-
   @Override
   protected BuildingList load() {
     logger.debug("Loading buildings");
     return HttpConnection.getInstance().execute("lists/"
-            + "buildings", CallType.GET, new BuildingListResultHandler(), session);
+            + "buildings", CallType.GET, new BuildingListResultHandler(), true);
   }
 
   @Override

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/EconomyListLoader.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/EconomyListLoader.java
@@ -11,15 +11,11 @@ import org.slf4j.LoggerFactory;
 public class EconomyListLoader extends Loader<EconomyList> {
   private static final Logger logger = LoggerFactory.getLogger(EconomyListLoader.class);
 
-  public EconomyListLoader(Session session) {
-    super(session);
-  }
-
   @Override
   public EconomyList load() {
     logger.debug("Loading economies");
     return HttpConnection.getInstance().execute("lists/"
-            + "economies", CallType.GET, new EconomyListResultHandler(), session);
+            + "economies", CallType.GET, new EconomyListResultHandler(), true);
   }
 
   @Override

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/FunctionMapLoader.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/FunctionMapLoader.java
@@ -11,15 +11,11 @@ import org.slf4j.LoggerFactory;
 public class FunctionMapLoader extends Loader<FunctionMap> {
   private static final Logger logger = LoggerFactory.getLogger(FunctionMapLoader.class);
 
-  public FunctionMapLoader(Session session) {
-    super(session);
-  }
-
   @Override
   protected FunctionMap load() {
     logger.debug("Loading functions");
     return HttpConnection.getInstance().execute("lists/functions",
-        CallType.GET, new FunctionMapResultHandler(), session);
+        CallType.GET, new FunctionMapResultHandler(), true);
   }
 
   @Override

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/IndicatorListLoader.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/IndicatorListLoader.java
@@ -11,15 +11,11 @@ import org.slf4j.LoggerFactory;
 public class IndicatorListLoader extends Loader<IndicatorList> {
   private static final Logger logger = LoggerFactory.getLogger(IndicatorListLoader.class);
 
-  public IndicatorListLoader(Session session) {
-    super(session);
-  }
-
   @Override
   public IndicatorList load() {
     logger.debug("Loading indicators");
     return HttpConnection.getInstance().execute("lists/"
-            + "indicators", CallType.GET, new IndicatorListResultHandler(), session);
+            + "indicators", CallType.GET, new IndicatorListResultHandler(), true);
   }
 
   @Override

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/LandMapLoader.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/LandMapLoader.java
@@ -11,15 +11,11 @@ import org.slf4j.LoggerFactory;
 public class LandMapLoader extends Loader<LandMap> {
   private static final Logger logger = LoggerFactory.getLogger(LandMapLoader.class);
 
-  public LandMapLoader(Session session) {
-    super(session);
-  }
-
   @Override
   protected LandMap load() {
     logger.debug("Loading lands");
     return HttpConnection.getInstance().execute("lists/lands",
-            CallType.GET, new LandMapResultHandler(), session);
+            CallType.GET, new LandMapResultHandler(), true);
   }
 
   @Override

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/Loader.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/Loader.java
@@ -10,6 +10,9 @@ public abstract class Loader<T> {
   public Loader(Session session) {
     this.session = session;
   }
+  
+  public Loader() {
+  }  
 
   protected abstract T load();
 

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/ServerWordsLoader.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/ServerWordsLoader.java
@@ -11,15 +11,11 @@ import org.slf4j.LoggerFactory;
 public class ServerWordsLoader extends Loader<ServerWords> {
   private static final Logger logger = LoggerFactory.getLogger(ServerWordsLoader.class);
 
-  public ServerWordsLoader(Session session) {
-    super(session);
-  }
-
   @Override
   protected ServerWords load() {
     logger.debug("Loading ServerWords");
     return HttpConnection.getInstance().execute("lists/serverwords/",
-            CallType.GET, new ServerWordsResultHandler(), session);
+            CallType.GET, new ServerWordsResultHandler(), true);
   }
 
   @Override

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/StakeholderListLoader.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/StakeholderListLoader.java
@@ -19,15 +19,12 @@ import java.util.Set;
 public class StakeholderListLoader extends Loader<StakeholderList> {
   private static final Logger logger = LoggerFactory.getLogger(StakeholderListLoader.class);
 
-  public StakeholderListLoader(Session session) {
-    super(session);
-  }
 
   @Override
   public StakeholderList load() {
     logger.debug("Loading stakeholders");
     StakeholderList stakeholders = HttpConnection.getInstance().execute("lists/"
-            + "stakeholders/", CallType.GET, new StakeholderListResultHandler(), session);
+            + "stakeholders/", CallType.GET, new StakeholderListResultHandler(), true);
     setActions(stakeholders);
     return stakeholders;
   }
@@ -36,7 +33,7 @@ public class StakeholderListLoader extends Loader<StakeholderList> {
    * Load actions and assign their functions to stakeholders.
    */
   private void setActions(StakeholderList stakeholderList) {
-    ActionList actionList = new ActionListLoader(session).get();
+    ActionList actionList = new ActionListLoader().get();
     for (Action action : actionList) {
       Map<Integer, Boolean> activeForStakeholder = action.getActiveForStakeholder();
       Set<Integer> stakeholders = activeForStakeholder.keySet();

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/ZoneListLoader.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/api/loaders/ZoneListLoader.java
@@ -11,15 +11,11 @@ import org.slf4j.LoggerFactory;
 public class ZoneListLoader extends Loader<ZoneList> {
   private static final Logger logger = LoggerFactory.getLogger(ZoneListLoader.class);
 
-  public ZoneListLoader(Session session) {
-    super(session);
-  }
-
   @Override
   public ZoneList load() {
     logger.debug("Loading zones");
     return HttpConnection.getInstance().execute("lists/"
-            + "zones", CallType.GET, new ZoneListResultHandler(), session);
+            + "zones", CallType.GET, new ZoneListResultHandler(), true);
   }
 
   @Override

--- a/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/objects/PopUpHandler.java
+++ b/tygron-connect-api/src/main/java/nl/tudelft/contextproject/tygron/objects/PopUpHandler.java
@@ -3,7 +3,6 @@ package nl.tudelft.contextproject.tygron.objects;
 import nl.tudelft.contextproject.tygron.api.CallType;
 import nl.tudelft.contextproject.tygron.api.Environment;
 import nl.tudelft.contextproject.tygron.api.HttpConnection;
-import nl.tudelft.contextproject.tygron.api.Session;
 import nl.tudelft.contextproject.tygron.handlers.JsonObjectResultHandler;
 import nl.tudelft.contextproject.tygron.objects.PopUp.TypeValue;
 import nl.tudelft.contextproject.util.PolygonUtil;
@@ -33,7 +32,6 @@ public class PopUpHandler {
     PERMIT_REQUEST_APPROVED, PERMIT_REQUEST_REFUSED, ZONING_DIVERGED, PLAN_PERFORM_ASK
   }
   
-  private Session session;
   private Environment environment;
   
   private int version;
@@ -46,9 +44,8 @@ public class PopUpHandler {
    * @param session The session
    * @param stakeholderId The id of the player's stakeholder
    */
-  public PopUpHandler(Session session, int stakeholderId) {
-    this.session = session;
-    this.environment = session.getEnvironment();
+  public PopUpHandler(Environment env, int stakeholderId) {
+    this.environment = env;
     this.stakeholderId = stakeholderId;
     this.version = 0;
     this.requestsOpen = 0;
@@ -112,7 +109,7 @@ public class PopUpHandler {
    */
   public void loadPopUps() {
     JSONObject dataObject = HttpConnection.getInstance().getUpdate(new JsonObjectResultHandler(),
-            session, getRequestObject());
+            true, getRequestObject());
     if (dataObject != null) {
       JSONObject items = dataObject.getJSONObject("items");
       if (items.has("POPUPS")) {

--- a/tygron-connect-api/src/test/java/nl/tudelft/contextproject/tygron/api/HttpConnectionTest.java
+++ b/tygron-connect-api/src/test/java/nl/tudelft/contextproject/tygron/api/HttpConnectionTest.java
@@ -39,6 +39,9 @@ public class HttpConnectionTest {
 
   @Mock
   HttpClient client;
+  
+  @Mock
+  HttpConnectionData data;
 
   @Mock
   HttpResponse response;
@@ -63,10 +66,15 @@ public class HttpConnectionTest {
 
     when(settings.getUserName()).thenReturn("username");
     when(settings.getPassword()).thenReturn("password");
+    
+    when(data.getClientToken()).thenReturn("clientToken");
+    when(data.getServerToken()).thenReturn("serverToken");
 
     when(session.getId()).thenReturn(17);
 
     HttpConnection.setSettings(settings);
+    HttpConnection.setData(data);
+    
     connection = HttpConnection.getInstance();
 
     when(handler.handleResponse(any(HttpResponse.class))).thenReturn(
@@ -88,14 +96,6 @@ public class HttpConnectionTest {
   public void testDefaultHeaders() {
     connection.addDefaultHeaders(request);
     verify(request, atLeast(3)).setHeader(anyString(), anyString());
-  }
-
-  @Test
-  public void testApiUrlWithSession() {
-    String url = connection.getApiUrl("event", true);
-    verify(session).getId();
-    assertEquals("https://server2.tygron.com:3022/api/slots/17/event?f=JSON",
-        url);
   }
 
   @Test

--- a/tygron-connect-api/src/test/java/nl/tudelft/contextproject/tygron/api/HttpConnectionTest.java
+++ b/tygron-connect-api/src/test/java/nl/tudelft/contextproject/tygron/api/HttpConnectionTest.java
@@ -3,7 +3,6 @@ package nl.tudelft.contextproject.tygron.api;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -93,7 +92,7 @@ public class HttpConnectionTest {
 
   @Test
   public void testApiUrlWithSession() {
-    String url = connection.getApiUrl("event", session);
+    String url = connection.getApiUrl("event", true);
     verify(session).getId();
     assertEquals("https://server2.tygron.com:3022/api/slots/17/event?f=JSON",
         url);
@@ -101,7 +100,7 @@ public class HttpConnectionTest {
 
   @Test
   public void testApiUrl() {
-    String url = connection.getApiUrl("event", null);
+    String url = connection.getApiUrl("event", false);
     assertEquals("https://server2.tygron.com:3022/api/event?f=JSON", url);
   }
 
@@ -121,7 +120,7 @@ public class HttpConnectionTest {
   @Test
   public void testUpdate() {
     JSONObject obj = connection.getUpdate(new JsonObjectResultHandler(),
-        session, new JSONObject());
+        true, new JSONObject());
     assertEquals("response", obj.getString("responseResponse"));
   }
 }

--- a/tygron-connect-api/src/test/java/nl/tudelft/contextproject/tygron/api/SessionTest.java
+++ b/tygron-connect-api/src/test/java/nl/tudelft/contextproject/tygron/api/SessionTest.java
@@ -25,9 +25,6 @@ public class SessionTest {
   @Mock
   HttpConnection connection;
 
-  @Mock
-  JoinableSession joinableSession;
-
   String closeSessionEvent = "services/event/IOServicesEventType/CLOSE_SESSION/";
 
   /**
@@ -36,13 +33,10 @@ public class SessionTest {
   @Before
   public void createSession() {
 
-    when(joinableSession.getId()).thenReturn(0);
-    when(joinableSession.getType()).thenReturn(null);
-
     String file = "/serverResponses/login.json";
     String loginContents = CachedFileReader.getFileContents(file);
     JSONObject loginResult = new JSONObject(loginContents);
-    session = new Session(joinableSession, loginResult);
+    session = new Session(0, loginResult);
 
     when(connection.execute(eq(closeSessionEvent), eq(CallType.POST), 
         any(BooleanResultHandler.class), any(Session.CloseSessionRequest.class))).thenReturn(true);
@@ -60,13 +54,6 @@ public class SessionTest {
     assertEquals("db45ba46-6c7f-4021-92e2-8865674e3837", session.getClientToken());
     session.setClientToken("token change");
     assertEquals("token change", session.getClientToken());
-  }
-
-  @Test
-  public void typeTest() {
-    assertEquals(null, session.getType());
-    session.setType("type change");
-    assertEquals("type change", session.getType());
   }
 
   @Test


### PR DESCRIPTION
Removed session calls/passing on where it was not needed. This also led to the partly refactor of the Environment and PopupHandler, which all do no longer need a session anymore for their calls. We now got less circular dependencies between classes.
